### PR TITLE
Add seekable lyrics and tap sync timing

### DIFF
--- a/src/main/kotlin/com/example/karaoke/lyrics/LrcWriter.kt
+++ b/src/main/kotlin/com/example/karaoke/lyrics/LrcWriter.kt
@@ -1,0 +1,27 @@
+package com.example.karaoke.lyrics
+
+import ui.LyricLine
+import java.io.File
+
+/** Utility for writing lyric lines to an LRC file. */
+object LrcWriter {
+    /** Writes [lines] to [file] in simple `.lrc` format. */
+    fun write(lines: List<LyricLine>, file: File) {
+        val content = buildString {
+            lines.forEach { line ->
+                append(formatTimestamp(line.timeMillis))
+                append(line.text)
+                append('\n')
+            }
+        }
+        file.writeText(content)
+    }
+
+    private fun formatTimestamp(ms: Long): String {
+        val totalSeconds = ms / 1000
+        val minutes = totalSeconds / 60
+        val seconds = totalSeconds % 60
+        val hundredths = (ms % 1000) / 10
+        return "[%02d:%02d.%02d]".format(minutes, seconds, hundredths)
+    }
+}

--- a/src/main/kotlin/ui/LyricView.kt
+++ b/src/main/kotlin/ui/LyricView.kt
@@ -2,6 +2,7 @@ package ui
 
 import androidx.compose.animation.core.withFrameNanos
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
@@ -29,7 +30,8 @@ data class LyricLine(val timeMillis: Long, val text: String)
 fun LyricView(
     lyrics: List<LyricLine>,
     currentTime: Long,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    onLineClick: (LyricLine) -> Unit = {}
 ) {
     val listState = rememberLazyListState()
     val currentIndex = remember(currentTime) {
@@ -61,6 +63,7 @@ fun LyricView(
             Column(
                 modifier = Modifier
                     .fillMaxWidth()
+                    .clickable { onLineClick(line) }
                     .background(
                         if (isActive) MaterialTheme.colorScheme.primary.copy(alpha = 0.1f)
                         else Color.Transparent

--- a/src/main/kotlin/ui/TapSyncPanel.kt
+++ b/src/main/kotlin/ui/TapSyncPanel.kt
@@ -1,0 +1,51 @@
+package ui
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.material3.Button
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+
+@Composable
+fun TapSyncPanel(
+    isRunning: Boolean,
+    tapCount: Int,
+    totalLines: Int,
+    onStart: () -> Unit,
+    onStop: () -> Unit,
+    onReset: () -> Unit,
+    onSave: () -> Unit,
+    onTap: () -> Unit,
+    onClose: () -> Unit
+) {
+    Dialog(onCloseRequest = onClose) {
+        Surface {
+            Column(
+                modifier = Modifier.padding(16.dp),
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
+                Text("$tapCount / $totalLines taps")
+                Spacer(Modifier.height(8.dp))
+                Button(onClick = onTap, enabled = isRunning) { Text("Tap") }
+                Spacer(Modifier.height(16.dp))
+                Row(
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Button(onClick = if (isRunning) onStop else onStart) {
+                        Text(if (isRunning) "Stop" else "Start")
+                    }
+                    Spacer(Modifier.width(8.dp))
+                    Button(onClick = onReset) { Text("Reset") }
+                    Spacer(Modifier.width(8.dp))
+                    Button(onClick = onSave, enabled = tapCount == totalLines) {
+                        Text("Save")
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Allow clicking lyric lines to seek playback
- Introduce Tap Sync Mode with start/stop/reset/save controls
- Write updated timestamps to LRC file via new LrcWriter

## Testing
- `kotlinc src/main/kotlin/**/*.kt -d build/app.jar` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689defd777e48322a42affdd9cf5f4c3