### PR TITLE
Add playlist model and panel with JSON persistence

### DIFF
--- a/src/main/kotlin/Main.kt
+++ b/src/main/kotlin/Main.kt
@@ -1,11 +1,16 @@
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.*
 import androidx.compose.ui.window.*
+import androidx.compose.foundation.layout.*
+import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.delay
 import ui.LyricLine
 import ui.LyricView
 import ui.TapSyncPanel
+import ui.PlaylistPanel
 import com.example.karaoke.lyrics.LrcWriter
+import com.example.karaoke.model.PlaylistStorage
+import com.example.karaoke.model.Track
 import java.io.File
 
 /**
@@ -27,6 +32,12 @@ fun main() = application {
         }
     ) {
         MaterialTheme {
+            val playlistFile = File("playlist.json")
+            val playlist = remember { mutableStateListOf<Track>() }
+            LaunchedEffect(Unit) { playlist.addAll(PlaylistStorage.load(playlistFile)) }
+            fun savePlaylist() = PlaylistStorage.save(playlistFile, playlist)
+
+            var currentTrackIndex by remember { mutableStateOf(-1) }
             var lyrics by remember {
                 mutableStateOf(
                     listOf(
@@ -38,14 +49,23 @@ fun main() = application {
                 )
             }
             var currentTime by remember { mutableStateOf(0L) }
-            var isPlaying by remember { mutableStateOf(true) }
+            var isPlaying by remember { mutableStateOf(false) }
             val tapTimes = remember { mutableStateListOf<Long>() }
             var tapRunning by remember { mutableStateOf(false) }
 
-            LaunchedEffect(isPlaying) {
-                while (isPlaying) {
+            LaunchedEffect(isPlaying, currentTrackIndex) {
+                while (isPlaying && currentTrackIndex in playlist.indices) {
                     delay(100)
                     currentTime += 100
+                    val duration = playlist[currentTrackIndex].durationMs
+                    if (currentTime >= duration) {
+                        if (currentTrackIndex + 1 < playlist.size) {
+                            currentTrackIndex++
+                            currentTime = 0L
+                        } else {
+                            isPlaying = false
+                        }
+                    }
                 }
             }
 
@@ -83,11 +103,60 @@ fun main() = application {
                 )
             }
 
-            LyricView(
-                lyrics = lyrics,
-                currentTime = currentTime,
-                onLineClick = { line -> currentTime = line.timeMillis }
-            )
+            Row {
+                PlaylistPanel(
+                    tracks = playlist,
+                    currentIndex = currentTrackIndex,
+                    onPlay = { index ->
+                        currentTrackIndex = index
+                        currentTime = 0L
+                        isPlaying = true
+                    },
+                    onAdd = {
+                        playlist.add(it)
+                        savePlaylist()
+                    },
+                    onRemove = { index ->
+                        playlist.removeAt(index)
+                        savePlaylist()
+                        if (currentTrackIndex == index) {
+                            isPlaying = false
+                            currentTime = 0L
+                            currentTrackIndex = -1
+                        } else if (index < currentTrackIndex) {
+                            currentTrackIndex--
+                        }
+                    },
+                    onMove = { from, to ->
+                        val t = playlist.removeAt(from)
+                        playlist.add(to, t)
+                        savePlaylist()
+                        if (currentTrackIndex == from) currentTrackIndex = to
+                        else if (from < currentTrackIndex && to >= currentTrackIndex) currentTrackIndex--
+                        else if (from > currentTrackIndex && to <= currentTrackIndex) currentTrackIndex++
+                    },
+                    onNext = {
+                        if (currentTrackIndex + 1 < playlist.size) {
+                            currentTrackIndex++
+                            currentTime = 0L
+                        }
+                    },
+                    onPrev = {
+                        if (currentTrackIndex > 0) {
+                            currentTrackIndex--
+                            currentTime = 0L
+                        }
+                    },
+                    modifier = Modifier.width(200.dp)
+                )
+
+                LyricView(
+                    lyrics = lyrics,
+                    currentTime = currentTime,
+                    modifier = Modifier.weight(1f),
+                    onLineClick = { line -> currentTime = line.timeMillis }
+                )
+            }
         }
     }
 }

--- a/src/main/kotlin/com/example/karaoke/model/Track.kt
+++ b/src/main/kotlin/com/example/karaoke/model/Track.kt
@@ -1,0 +1,32 @@
+package com.example.karaoke.model
+
+import java.io.File
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.builtins.ListSerializer
+import kotlinx.serialization.json.Json
+
+/**
+ * Represents a playable track consisting of an audio file and optional lyric
+ * file along with some descriptive metadata.
+ */
+@Serializable
+data class Track(
+    val audioPath: String,
+    val lyricPath: String,
+    val title: String,
+    val artist: String,
+    val durationMs: Long
+)
+
+/** Utility object for persisting playlists as JSON. */
+object PlaylistStorage {
+    private val json = Json { prettyPrint = true }
+
+    fun load(file: File): List<Track> =
+        if (file.exists()) json.decodeFromString(ListSerializer(Track.serializer()), file.readText())
+        else emptyList()
+
+    fun save(file: File, tracks: List<Track>) {
+        file.writeText(json.encodeToString(ListSerializer(Track.serializer()), tracks))
+    }
+}

--- a/src/main/kotlin/ui/PlaylistPanel.kt
+++ b/src/main/kotlin/ui/PlaylistPanel.kt
@@ -1,0 +1,108 @@
+package ui
+
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.background
+import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.*
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import com.example.karaoke.model.Track
+import java.awt.FileDialog
+import java.awt.Frame
+import java.io.File
+
+/** Panel displaying a playlist with basic controls. */
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+fun PlaylistPanel(
+    tracks: MutableList<Track>,
+    currentIndex: Int,
+    onPlay: (Int) -> Unit,
+    onAdd: (Track) -> Unit,
+    onRemove: (Int) -> Unit,
+    onMove: (Int, Int) -> Unit,
+    onNext: () -> Unit,
+    onPrev: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    var selectedIndex by remember { mutableStateOf(-1) }
+
+    Column(modifier.padding(8.dp)) {
+        Row {
+            Button(onClick = {
+                newTrack()?.let {
+                    onAdd(it)
+                    selectedIndex = tracks.lastIndex
+                }
+            }) { Text("Add") }
+            Spacer(Modifier.width(4.dp))
+            Button(onClick = {
+                if (selectedIndex >= 0) {
+                    onRemove(selectedIndex)
+                    selectedIndex = -1
+                }
+            }) { Text("Remove") }
+            Spacer(Modifier.width(4.dp))
+            Button(onClick = {
+                if (selectedIndex > 0) {
+                    onMove(selectedIndex, selectedIndex - 1)
+                    selectedIndex--
+                }
+            }) { Text("Up") }
+            Spacer(Modifier.width(4.dp))
+            Button(onClick = {
+                if (selectedIndex >= 0 && selectedIndex < tracks.lastIndex) {
+                    onMove(selectedIndex, selectedIndex + 1)
+                    selectedIndex++
+                }
+            }) { Text("Down") }
+            Spacer(Modifier.width(4.dp))
+            Button(onClick = onPrev, enabled = tracks.isNotEmpty()) { Text("Prev") }
+            Spacer(Modifier.width(4.dp))
+            Button(onClick = onNext, enabled = tracks.isNotEmpty()) { Text("Next") }
+        }
+
+        LazyColumn(modifier.fillMaxHeight().padding(top = 8.dp)) {
+            itemsIndexed(tracks) { index, track ->
+                val isSelected = index == selectedIndex
+                val bg = when {
+                    index == currentIndex -> MaterialTheme.colorScheme.primary.copy(alpha = 0.3f)
+                    isSelected -> MaterialTheme.colorScheme.primary.copy(alpha = 0.15f)
+                    else -> Color.Transparent
+                }
+                Text(
+                    "${track.title} - ${track.artist}",
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .background(bg)
+                        .combinedClickable(
+                            onClick = { selectedIndex = index },
+                            onDoubleClick = { onPlay(index) }
+                        )
+                        .padding(4.dp)
+                )
+            }
+        }
+    }
+}
+
+private fun newTrack(): Track? {
+    val audio = pickFile("Select audio") ?: return null
+    val lyric = pickFile("Select lyrics", required = false) ?: ""
+    val title = File(audio).nameWithoutExtension
+    return Track(audio, lyric, title, artist = "", durationMs = 30_000)
+}
+
+private fun pickFile(title: String, required: Boolean = true): String? {
+    val fd = FileDialog(null as Frame?, title, FileDialog.LOAD)
+    fd.isVisible = true
+    val file = fd.file ?: return if (required) null else ""
+    return fd.directory + file
+}


### PR DESCRIPTION
## Summary
- introduce `Track` data class and JSON playlist persistence helpers
- add `PlaylistPanel` for adding, removing, reordering, and playing tracks
- wire playlist into main app with auto-advance and next/prev controls

## Testing
- `./gradlew test` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689df1a746208322b22a78b6a66c4f64