### PR TITLE
Add waveform overview and audio level meter

### DIFF
--- a/src/main/kotlin/com/example/karaoke/audio/AudioEngine.kt
+++ b/src/main/kotlin/com/example/karaoke/audio/AudioEngine.kt
@@ -30,6 +30,12 @@ interface AudioEngine {
      * negative lowers. The range is expected to be within ±6 semitones.
      */
     fun setPitch(semitones: Float)
+
+    /**
+     * Register [listener] to receive real-time RMS and peak levels in the
+     * range 0.0–1.0. Pass `null` to remove the listener.
+     */
+    fun setLevelListener(listener: ((rms: Float, peak: Float) -> Unit)?)
 }
 
 /** Available audio backends. */

--- a/src/main/kotlin/com/example/karaoke/audio/JavaFXAudioEngine.kt
+++ b/src/main/kotlin/com/example/karaoke/audio/JavaFXAudioEngine.kt
@@ -1,18 +1,35 @@
 package com.example.karaoke.audio
 
+import javafx.scene.media.AudioSpectrumListener
 import javafx.scene.media.Media
 import javafx.scene.media.MediaPlayer
 import javafx.util.Duration
 import java.io.File
 import kotlin.math.pow
+import kotlin.math.sqrt
 
 /** Audio engine based on JavaFX's [MediaPlayer]. */
 class JavaFXAudioEngine : AudioEngine {
     private var player: MediaPlayer? = null
+    private var levelListener: ((Float, Float) -> Unit)? = null
 
     override fun load(file: File) {
         player?.dispose()
-        player = MediaPlayer(Media(file.toURI().toString()))
+        player = MediaPlayer(Media(file.toURI().toString())).apply {
+            audioSpectrumInterval = 0.1
+            audioSpectrumNumBands = 64
+            audioSpectrumListener = AudioSpectrumListener { _, _, magnitudes, _ ->
+                var peak = 0f
+                var sum = 0f
+                for (m in magnitudes) {
+                    val amp = 10f.pow(m / 20f)
+                    sum += amp * amp
+                    if (amp > peak) peak = amp
+                }
+                val rms = sqrt(sum / magnitudes.size)
+                levelListener?.invoke(rms, peak)
+            }
+        }
     }
 
     override fun play() {
@@ -42,5 +59,9 @@ class JavaFXAudioEngine : AudioEngine {
         // to approximate the requested pitch shift.
         val factor = 2.0.pow(semitones / 12.0)
         player?.rate = factor
+    }
+
+    override fun setLevelListener(listener: ((rms: Float, peak: Float) -> Unit)?) {
+        levelListener = listener
     }
 }

--- a/src/main/kotlin/com/example/karaoke/audio/Waveform.kt
+++ b/src/main/kotlin/com/example/karaoke/audio/Waveform.kt
@@ -1,0 +1,41 @@
+package com.example.karaoke.audio
+
+import be.tarsos.dsp.AudioEvent
+import be.tarsos.dsp.AudioProcessor
+import be.tarsos.dsp.io.jvm.AudioDispatcherFactory
+import java.io.File
+import kotlin.math.abs
+
+/**
+ * Utility to extract a simple waveform peak envelope from [file]. The result
+ * contains [points] values in the range 0.0–1.0 representing peaks across the
+ * track duration.
+ */
+fun extractWaveform(file: File, points: Int = 1000): List<Float> {
+    val dispatcher = AudioDispatcherFactory.fromPipe(file.absolutePath, 44_100, 2048, 0)
+    val peaks = mutableListOf<Float>()
+    dispatcher.addAudioProcessor(object : AudioProcessor {
+        override fun process(event: AudioEvent): Boolean {
+            var peak = 0f
+            for (s in event.floatBuffer) {
+                val a = abs(s)
+                if (a > peak) peak = a
+            }
+            peaks += peak
+            return true
+        }
+
+        override fun processingFinished() {}
+    })
+    dispatcher.run()
+
+    if (peaks.isEmpty()) return emptyList()
+    if (peaks.size <= points) return peaks
+    val result = MutableList(points) { 0f }
+    val ratio = peaks.size.toFloat() / points
+    for (i in peaks.indices) {
+        val idx = (i / ratio).toInt()
+        if (peaks[i] > result[idx]) result[idx] = peaks[i]
+    }
+    return result
+}

--- a/src/main/kotlin/ui/LevelMeter.kt
+++ b/src/main/kotlin/ui/LevelMeter.kt
@@ -1,0 +1,22 @@
+package ui
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.background
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Color
+
+/** Displays a simple RMS/peak level meter. */
+@Composable
+fun LevelMeter(rms: Float, peak: Float, modifier: Modifier = Modifier) {
+    Canvas(modifier.background(Color.Black)) {
+        val w = size.width
+        val h = size.height
+        val rmsH = (rms.coerceIn(0f, 1f)) * h
+        val peakH = (peak.coerceIn(0f, 1f)) * h
+        drawRect(Color.Green, Offset(0f, h - rmsH), Size(w, rmsH))
+        drawLine(Color.Red, Offset(0f, h - peakH), Offset(w, h - peakH), strokeWidth = 2f)
+    }
+}

--- a/src/main/kotlin/ui/WaveformView.kt
+++ b/src/main/kotlin/ui/WaveformView.kt
@@ -1,0 +1,61 @@
+package ui
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.gestures.detectDragGestures
+import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.pointer.pointerInput
+
+/**
+ * Draws a miniature waveform and a draggable playhead that can seek within the
+ * track.
+ */
+@Composable
+fun WaveformView(
+    waveform: List<Float>,
+    positionMs: Long,
+    durationMs: Long,
+    onSeek: (Long) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val dragModifier = modifier
+        .pointerInput(durationMs) {
+            detectTapGestures { offset ->
+                val ratio = offset.x / size.width
+                onSeek((durationMs * ratio).toLong())
+            }
+        }
+        .pointerInput(durationMs) {
+            detectDragGestures { change, _ ->
+                val ratio = change.position.x / size.width
+                onSeek((durationMs * ratio).toLong())
+            }
+        }
+
+    Canvas(dragModifier) {
+        val w = size.width
+        val h = size.height
+        if (waveform.isNotEmpty()) {
+            val step = (waveform.size / w).coerceAtLeast(1f)
+            var x = 0f
+            while (x < w) {
+                val idx = (x * step).toInt().coerceIn(0, waveform.lastIndex)
+                val amp = waveform[idx].coerceIn(0f, 1f)
+                val y = amp * h / 2f
+                drawLine(
+                    Color.Gray,
+                    Offset(x, h / 2 - y),
+                    Offset(x, h / 2 + y),
+                    strokeWidth = 1f
+                )
+                x += 1f
+            }
+        }
+        val progress = if (durationMs > 0) positionMs.toFloat() / durationMs else 0f
+        val playX = progress * w
+        drawLine(Color.Red, Offset(playX, 0f), Offset(playX, h), strokeWidth = 2f)
+    }
+}


### PR DESCRIPTION
## Summary
- add RMS/peak level listener to audio engines
- draw waveform with draggable playhead and level meter
- support waveform extraction for tracks

## Testing
- `gradle build` *(fails: Could not resolve dependencies, status code 403)*

------
https://chatgpt.com/codex/tasks/task_e_689df564c0bc83229d12e8da902b2897