### PR TITLE
Add configurable settings dialog and global shortcuts

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     kotlin("jvm") version "1.9.0"
     id("org.jetbrains.compose") version "1.5.0"
+    kotlin("plugin.serialization") version "1.9.0"
 }
 
 repositories {
@@ -12,6 +13,7 @@ repositories {
 dependencies {
     implementation(compose.desktop.currentOs)
     implementation("be.tarsos:dsp:2.5")
+    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.5.1")
 }
 
 compose.desktop {

--- a/src/main/kotlin/Main.kt
+++ b/src/main/kotlin/Main.kt
@@ -1,8 +1,10 @@
-import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.window.*
 import androidx.compose.foundation.layout.*
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.input.key.*
+import androidx.compose.ui.graphics.Color
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -12,67 +14,147 @@ import ui.TapSyncPanel
 import ui.PlaylistPanel
 import ui.WaveformView
 import ui.LevelMeter
+import ui.SettingsDialog
 import com.example.karaoke.lyrics.LrcWriter
+import com.example.karaoke.lyrics.LrcReader
 import com.example.karaoke.model.PlaylistStorage
 import com.example.karaoke.model.Track
+import com.example.karaoke.model.Settings
+import com.example.karaoke.model.SettingsStorage
+import com.example.karaoke.model.Theme as AppTheme
 import com.example.karaoke.audio.AudioEngine
 import com.example.karaoke.audio.EngineType
 import com.example.karaoke.audio.JavaFXAudioEngine
 import com.example.karaoke.audio.TarsosAudioEngine
 import com.example.karaoke.audio.extractWaveform
-import androidx.compose.material3.Slider
-import androidx.compose.material3.Button
-import androidx.compose.material3.Text
-import androidx.compose.foundation.layout.Column
 import java.io.File
+import java.awt.FileDialog
+import java.awt.Frame
 
-/**
- * Entry point showcasing the [LyricView]. It advances [currentTime] every
- * few milliseconds to emulate audio playback.
- */
 fun main() = application {
     var showTapSync by remember { mutableStateOf(false) }
+    var showSettings by remember { mutableStateOf(false) }
+    var showPlaylist by remember { mutableStateOf(true) }
+    val settingsFile = File("settings.json")
+    var settings by remember { mutableStateOf(SettingsStorage.load(settingsFile)) }
+
+    val playlistFile = File("playlist.json")
+    val playlist = remember { mutableStateListOf<Track>() }
+    var currentTrackIndex by remember { mutableStateOf(-1) }
+    var lyrics by remember {
+        mutableStateOf(
+            listOf(
+                LyricLine(0L, "Line 1"),
+                LyricLine(3000L, "Line 2"),
+                LyricLine(6000L, "Line 3"),
+                LyricLine(9000L, "Line 4")
+            )
+        )
+    }
+    var currentTime by remember { mutableStateOf(0L) }
+    var isPlaying by remember { mutableStateOf(false) }
+    var engineType by remember { mutableStateOf(settings.defaultEngine) }
+    var audioEngine by remember {
+        mutableStateOf<AudioEngine>(
+            when (settings.defaultEngine) {
+                EngineType.JavaFX -> JavaFXAudioEngine()
+                EngineType.TarsosDSP -> TarsosAudioEngine()
+            }
+        )
+    }
+    var tempo by remember { mutableStateOf(1f) }
+    var pitch by remember { mutableStateOf(0f) }
+    var volume by remember { mutableStateOf(settings.defaultVolume) }
+    var lyricsFontSize by remember { mutableStateOf(settings.lyricsFontSize) }
+    val tapTimes = remember { mutableStateListOf<Long>() }
+    var tapRunning by remember { mutableStateOf(false) }
+    var waveform by remember { mutableStateOf<List<Float>>(emptyList()) }
+    var rmsLevel by remember { mutableStateOf(0f) }
+    var peakLevel by remember { mutableStateOf(0f) }
+
+    LaunchedEffect(Unit) { playlist.addAll(PlaylistStorage.load(playlistFile)) }
+    fun savePlaylist() = PlaylistStorage.save(playlistFile, playlist)
+
+    fun openAudio() {
+        val fd = FileDialog(null as Frame?, "Select audio", FileDialog.LOAD)
+        fd.isVisible = true
+        val file = fd.file ?: return
+        val path = fd.directory + file
+        val track = Track(path, "", File(path).nameWithoutExtension, artist = "", durationMs = 30_000)
+        playlist.add(track)
+        savePlaylist()
+        currentTrackIndex = playlist.lastIndex
+        currentTime = 0L
+        audioEngine.load(File(path))
+    }
+
+    fun openLyrics() {
+        val fd = FileDialog(null as Frame?, "Select lyrics", FileDialog.LOAD)
+        fd.isVisible = true
+        val file = fd.file ?: return
+        val path = fd.directory + file
+        lyrics = LrcReader.read(File(path))
+    }
+
+    fun parseColor(hex: String): Color {
+        return try {
+            val c = java.awt.Color.decode(hex)
+            Color(c.red, c.green, c.blue)
+        } catch (e: Exception) {
+            Color(0xFF6200EE)
+        }
+    }
 
     Window(
         onCloseRequest = ::exitApplication,
         title = "Lyrics",
+        onPreviewKeyEvent = {
+            if (it.type == KeyEventType.KeyDown) {
+                when {
+                    it.key == Key.Spacebar -> {
+                        if (isPlaying) audioEngine.pause() else audioEngine.play()
+                        isPlaying = !isPlaying
+                        true
+                    }
+                    it.key == Key.DirectionLeft -> {
+                        currentTime = (currentTime - 5000).coerceAtLeast(0)
+                        audioEngine.seek(currentTime)
+                        true
+                    }
+                    it.key == Key.DirectionRight -> {
+                        val duration = playlist.getOrNull(currentTrackIndex)?.durationMs ?: Long.MAX_VALUE
+                        currentTime = (currentTime + 5000).coerceAtMost(duration)
+                        audioEngine.seek(currentTime)
+                        true
+                    }
+                    it.key == Key.DirectionUp -> {
+                        volume = (volume + 0.05f).coerceAtMost(1f)
+                        audioEngine.setVolume(volume)
+                        true
+                    }
+                    it.key == Key.DirectionDown -> {
+                        volume = (volume - 0.05f).coerceAtLeast(0f)
+                        audioEngine.setVolume(volume)
+                        true
+                    }
+                    it.isCtrlPressed && it.key == Key.O -> { openAudio(); true }
+                    it.isCtrlPressed && it.key == Key.L -> { openLyrics(); true }
+                    it.isCtrlPressed && it.key == Key.P -> { showPlaylist = !showPlaylist; true }
+                    else -> false
+                }
+            } else false
+        },
         menuBar = {
             MenuBar {
-                Menu("Tools") {
-                    Item("Tap Sync Mode", onClick = { showTapSync = true })
-                }
+                Menu("File") { Item("Settings", onClick = { showSettings = true }) }
+                Menu("Tools") { Item("Tap Sync Mode", onClick = { showTapSync = true }) }
             }
         }
     ) {
-        MaterialTheme {
-            val playlistFile = File("playlist.json")
-            val playlist = remember { mutableStateListOf<Track>() }
-            LaunchedEffect(Unit) { playlist.addAll(PlaylistStorage.load(playlistFile)) }
-            fun savePlaylist() = PlaylistStorage.save(playlistFile, playlist)
-
-            var currentTrackIndex by remember { mutableStateOf(-1) }
-            var lyrics by remember {
-                mutableStateOf(
-                    listOf(
-                        LyricLine(0L, "Line 1"),
-                        LyricLine(3000L, "Line 2"),
-                        LyricLine(6000L, "Line 3"),
-                        LyricLine(9000L, "Line 4")
-                    )
-                )
-            }
-            var currentTime by remember { mutableStateOf(0L) }
-            var isPlaying by remember { mutableStateOf(false) }
-            var engineType by remember { mutableStateOf(EngineType.JavaFX) }
-            var audioEngine by remember { mutableStateOf<AudioEngine>(JavaFXAudioEngine()) }
-            var tempo by remember { mutableStateOf(1f) }
-            var pitch by remember { mutableStateOf(0f) }
-            val tapTimes = remember { mutableStateListOf<Long>() }
-            var tapRunning by remember { mutableStateOf(false) }
-            var waveform by remember { mutableStateOf<List<Float>>(emptyList()) }
-            var rmsLevel by remember { mutableStateOf(0f) }
-            var peakLevel by remember { mutableStateOf(0f) }
-
+        val colorScheme = if (settings.theme == AppTheme.Dark)
+            darkColorScheme(primary = parseColor(settings.karaokeColor))
+        else lightColorScheme(primary = parseColor(settings.karaokeColor))
+        MaterialTheme(colorScheme = colorScheme) {
             LaunchedEffect(engineType) {
                 val pos = currentTime
                 audioEngine.stop()
@@ -84,6 +166,7 @@ fun main() = application {
                     rmsLevel = rms
                     peakLevel = peak
                 }
+                audioEngine.setVolume(volume)
                 if (currentTrackIndex in playlist.indices) {
                     val track = playlist[currentTrackIndex]
                     audioEngine.load(File(track.audioPath))
@@ -96,11 +179,11 @@ fun main() = application {
 
             LaunchedEffect(currentTrackIndex) {
                 waveform = if (currentTrackIndex in playlist.indices) {
-                    withContext(Dispatchers.IO) {
-                        extractWaveform(File(playlist[currentTrackIndex].audioPath))
-                    }
+                    withContext(Dispatchers.IO) { extractWaveform(File(playlist[currentTrackIndex].audioPath)) }
                 } else emptyList()
             }
+
+            LaunchedEffect(volume, audioEngine) { audioEngine.setVolume(volume) }
 
             LaunchedEffect(isPlaying, currentTrackIndex, audioEngine) {
                 while (isPlaying && currentTrackIndex in playlist.indices) {
@@ -158,6 +241,20 @@ fun main() = application {
                 )
             }
 
+            if (showSettings) {
+                SettingsDialog(
+                    current = settings,
+                    onSave = {
+                        settings = it
+                        engineType = it.defaultEngine
+                        volume = it.defaultVolume
+                        lyricsFontSize = it.lyricsFontSize
+                        SettingsStorage.save(settingsFile, it)
+                    },
+                    onClose = { showSettings = false }
+                )
+            }
+
             Column {
                 if (currentTrackIndex in playlist.indices) {
                     val duration = playlist[currentTrackIndex].durationMs
@@ -174,71 +271,74 @@ fun main() = application {
                 }
 
                 Row {
-                    PlaylistPanel(
-                        tracks = playlist,
-                        currentIndex = currentTrackIndex,
-                        onPlay = { index ->
-                            currentTrackIndex = index
-                            currentTime = 0L
-                            val track = playlist[index]
-                            audioEngine.load(File(track.audioPath))
-                            audioEngine.setTempo(tempo)
-                            audioEngine.setPitch(pitch)
-                            audioEngine.play()
-                            isPlaying = true
-                        },
-                    onAdd = {
-                        playlist.add(it)
-                        savePlaylist()
-                    },
-                    onRemove = { index ->
-                        playlist.removeAt(index)
-                        savePlaylist()
-                        if (currentTrackIndex == index) {
-                            isPlaying = false
-                            currentTime = 0L
-                            currentTrackIndex = -1
-                        } else if (index < currentTrackIndex) {
-                            currentTrackIndex--
-                        }
-                    },
-                    onMove = { from, to ->
-                        val t = playlist.removeAt(from)
-                        playlist.add(to, t)
-                        savePlaylist()
-                        if (currentTrackIndex == from) currentTrackIndex = to
-                        else if (from < currentTrackIndex && to >= currentTrackIndex) currentTrackIndex--
-                        else if (from > currentTrackIndex && to <= currentTrackIndex) currentTrackIndex++
-                    },
-                    onNext = {
-                        if (currentTrackIndex + 1 < playlist.size) {
-                            currentTrackIndex++
-                            currentTime = 0L
-                            val track = playlist[currentTrackIndex]
-                            audioEngine.load(File(track.audioPath))
-                            audioEngine.setTempo(tempo)
-                            audioEngine.setPitch(pitch)
-                            if (isPlaying) audioEngine.play()
-                        }
-                    },
-                    onPrev = {
-                        if (currentTrackIndex > 0) {
-                            currentTrackIndex--
-                            currentTime = 0L
-                            val track = playlist[currentTrackIndex]
-                            audioEngine.load(File(track.audioPath))
-                            audioEngine.setTempo(tempo)
-                            audioEngine.setPitch(pitch)
-                            if (isPlaying) audioEngine.play()
-                        }
-                    },
-                    modifier = Modifier.width(200.dp)
-                    )
+                    if (showPlaylist) {
+                        PlaylistPanel(
+                            tracks = playlist,
+                            currentIndex = currentTrackIndex,
+                            onPlay = { index ->
+                                currentTrackIndex = index
+                                currentTime = 0L
+                                val track = playlist[index]
+                                audioEngine.load(File(track.audioPath))
+                                audioEngine.setTempo(tempo)
+                                audioEngine.setPitch(pitch)
+                                audioEngine.play()
+                                isPlaying = true
+                            },
+                            onAdd = {
+                                playlist.add(it)
+                                savePlaylist()
+                            },
+                            onRemove = { index ->
+                                playlist.removeAt(index)
+                                savePlaylist()
+                                if (currentTrackIndex == index) {
+                                    isPlaying = false
+                                    currentTime = 0L
+                                    currentTrackIndex = -1
+                                } else if (index < currentTrackIndex) {
+                                    currentTrackIndex--
+                                }
+                            },
+                            onMove = { from, to ->
+                                val t = playlist.removeAt(from)
+                                playlist.add(to, t)
+                                savePlaylist()
+                                if (currentTrackIndex == from) currentTrackIndex = to
+                                else if (from < currentTrackIndex && to >= currentTrackIndex) currentTrackIndex--
+                                else if (from > currentTrackIndex && to <= currentTrackIndex) currentTrackIndex++
+                            },
+                            onNext = {
+                                if (currentTrackIndex + 1 < playlist.size) {
+                                    currentTrackIndex++
+                                    currentTime = 0L
+                                    val track = playlist[currentTrackIndex]
+                                    audioEngine.load(File(track.audioPath))
+                                    audioEngine.setTempo(tempo)
+                                    audioEngine.setPitch(pitch)
+                                    if (isPlaying) audioEngine.play()
+                                }
+                            },
+                            onPrev = {
+                                if (currentTrackIndex > 0) {
+                                    currentTrackIndex--
+                                    currentTime = 0L
+                                    val track = playlist[currentTrackIndex]
+                                    audioEngine.load(File(track.audioPath))
+                                    audioEngine.setTempo(tempo)
+                                    audioEngine.setPitch(pitch)
+                                    if (isPlaying) audioEngine.play()
+                                }
+                            },
+                            modifier = Modifier.width(200.dp),
+                        )
+                    }
 
                     LyricView(
                         lyrics = lyrics,
                         currentTime = currentTime,
                         modifier = Modifier.weight(1f),
+                        fontSize = lyricsFontSize,
                         onLineClick = { line ->
                             currentTime = line.timeMillis
                             audioEngine.seek(line.timeMillis)
@@ -251,6 +351,11 @@ fun main() = application {
                             Spacer(Modifier.width(4.dp))
                             Button(onClick = { engineType = EngineType.TarsosDSP }) { Text("TarsosDSP") }
                         }
+                        Text("Volume: ${(volume * 100).toInt()}%")
+                        Slider(value = volume, onValueChange = {
+                            volume = it
+                            audioEngine.setVolume(it)
+                        })
                         Text("Tempo: ${"%.2f".format(tempo)}x")
                         Slider(
                             value = tempo,

--- a/src/main/kotlin/com/example/karaoke/audio/AudioEngine.kt
+++ b/src/main/kotlin/com/example/karaoke/audio/AudioEngine.kt
@@ -1,6 +1,7 @@
 package com.example.karaoke.audio
 
 import java.io.File
+import kotlinx.serialization.Serializable
 
 /** Simple abstraction for audio playback so different engines can be swapped. */
 interface AudioEngine {
@@ -36,7 +37,11 @@ interface AudioEngine {
      * range 0.0–1.0. Pass `null` to remove the listener.
      */
     fun setLevelListener(listener: ((rms: Float, peak: Float) -> Unit)?)
+
+    /** Set playback volume in range 0.0–1.0. */
+    fun setVolume(volume: Float)
 }
 
 /** Available audio backends. */
+@Serializable
 enum class EngineType { JavaFX, TarsosDSP }

--- a/src/main/kotlin/com/example/karaoke/audio/JavaFXAudioEngine.kt
+++ b/src/main/kotlin/com/example/karaoke/audio/JavaFXAudioEngine.kt
@@ -64,4 +64,8 @@ class JavaFXAudioEngine : AudioEngine {
     override fun setLevelListener(listener: ((rms: Float, peak: Float) -> Unit)?) {
         levelListener = listener
     }
+
+    override fun setVolume(volume: Float) {
+        player?.volume = volume.toDouble()
+    }
 }

--- a/src/main/kotlin/com/example/karaoke/audio/TarsosAudioEngine.kt
+++ b/src/main/kotlin/com/example/karaoke/audio/TarsosAudioEngine.kt
@@ -5,6 +5,7 @@ import be.tarsos.dsp.AudioEvent
 import be.tarsos.dsp.AudioProcessor
 import be.tarsos.dsp.effects.PitchShifter
 import be.tarsos.dsp.effects.RateTransposer
+import be.tarsos.dsp.GainProcessor
 import be.tarsos.dsp.io.jvm.AudioDispatcherFactory
 import be.tarsos.dsp.io.jvm.AudioPlayer
 import java.io.File
@@ -23,6 +24,7 @@ class TarsosAudioEngine : AudioEngine {
     private var pitch: Float = 0f
     private var position: Long = 0L
     private var levelListener: ((Float, Float) -> Unit)? = null
+    private var volume: Float = 1f
 
     private val sampleRate = 44_100
     private val bufferSize = 2048
@@ -42,6 +44,7 @@ class TarsosAudioEngine : AudioEngine {
         val shift = PitchShifter(2f.pow(pitch / 12f), bufferSize, overlap)
         d.addAudioProcessor(rate)
         d.addAudioProcessor(shift)
+        d.addAudioProcessor(GainProcessor(volume.toDouble()))
         d.addAudioProcessor(object : AudioProcessor {
             override fun process(event: AudioEvent): Boolean {
                 val buffer = event.floatBuffer
@@ -99,5 +102,10 @@ class TarsosAudioEngine : AudioEngine {
 
     override fun setLevelListener(listener: ((rms: Float, peak: Float) -> Unit)?) {
         levelListener = listener
+    }
+
+    override fun setVolume(volume: Float) {
+        this.volume = volume
+        buildDispatcher(position)
     }
 }

--- a/src/main/kotlin/com/example/karaoke/lyrics/LrcReader.kt
+++ b/src/main/kotlin/com/example/karaoke/lyrics/LrcReader.kt
@@ -1,0 +1,21 @@
+package com.example.karaoke.lyrics
+
+import ui.LyricLine
+import java.io.File
+
+/** Simple parser for LRC lyric files. */
+object LrcReader {
+    private val regex = "\\[(\\d+):(\\d+\\.\\d+)\\]".toRegex()
+
+    fun read(file: File): List<LyricLine> {
+        if (!file.exists()) return emptyList()
+        return file.readLines().mapNotNull { line ->
+            val match = regex.find(line) ?: return@mapNotNull null
+            val min = match.groupValues[1].toLong()
+            val sec = match.groupValues[2].toDouble()
+            val time = min * 60_000 + (sec * 1000).toLong()
+            val text = line.substring(match.range.last + 1).trim()
+            LyricLine(time, text)
+        }.sortedBy { it.timeMillis }
+    }
+}

--- a/src/main/kotlin/com/example/karaoke/model/Settings.kt
+++ b/src/main/kotlin/com/example/karaoke/model/Settings.kt
@@ -1,0 +1,30 @@
+package com.example.karaoke.model
+
+import com.example.karaoke.audio.EngineType
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import java.io.File
+
+@Serializable
+enum class Theme { Light, Dark }
+
+@Serializable
+data class Settings(
+    val theme: Theme = Theme.Light,
+    val defaultEngine: EngineType = EngineType.JavaFX,
+    val defaultVolume: Float = 1f,
+    val lyricsFontSize: Int = 16,
+    val karaokeColor: String = "#6200EE"
+)
+
+object SettingsStorage {
+    private val json = Json { prettyPrint = true }
+
+    fun load(file: File): Settings =
+        if (file.exists()) json.decodeFromString(Settings.serializer(), file.readText())
+        else Settings()
+
+    fun save(file: File, settings: Settings) {
+        file.writeText(json.encodeToString(Settings.serializer(), settings))
+    }
+}

--- a/src/main/kotlin/ui/LyricView.kt
+++ b/src/main/kotlin/ui/LyricView.kt
@@ -15,6 +15,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 
 /**
  * Represents a line of lyric with its start time in milliseconds.
@@ -31,6 +32,7 @@ fun LyricView(
     lyrics: List<LyricLine>,
     currentTime: Long,
     modifier: Modifier = Modifier,
+    fontSize: Int = 16,
     onLineClick: (LyricLine) -> Unit = {}
 ) {
     val listState = rememberLazyListState()
@@ -72,7 +74,7 @@ fun LyricView(
             ) {
                 Text(
                     text = line.text,
-                    style = MaterialTheme.typography.bodyLarge,
+                    style = MaterialTheme.typography.bodyLarge.copy(fontSize = fontSize.sp),
                     color = if (isActive) MaterialTheme.colorScheme.primary
                     else MaterialTheme.colorScheme.onBackground
                 )

--- a/src/main/kotlin/ui/SettingsDialog.kt
+++ b/src/main/kotlin/ui/SettingsDialog.kt
@@ -1,0 +1,77 @@
+package ui
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import com.example.karaoke.audio.EngineType
+import com.example.karaoke.model.Settings
+import com.example.karaoke.model.Theme
+
+@Composable
+fun SettingsDialog(
+    current: Settings,
+    onSave: (Settings) -> Unit,
+    onClose: () -> Unit
+) {
+    var theme by remember { mutableStateOf(current.theme) }
+    var engine by remember { mutableStateOf(current.defaultEngine) }
+    var volume by remember { mutableStateOf(current.defaultVolume) }
+    var fontSize by remember { mutableStateOf(current.lyricsFontSize.toFloat()) }
+    var color by remember { mutableStateOf(current.karaokeColor) }
+
+    Dialog(onCloseRequest = onClose) {
+        Surface {
+            Column(Modifier.padding(16.dp)) {
+                Text("Theme")
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    RadioButton(selected = theme == Theme.Light, onClick = { theme = Theme.Light })
+                    Text("Light")
+                    Spacer(Modifier.width(8.dp))
+                    RadioButton(selected = theme == Theme.Dark, onClick = { theme = Theme.Dark })
+                    Text("Dark")
+                }
+
+                Spacer(Modifier.height(8.dp))
+                Text("Default Engine")
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    EngineType.values().forEach { et ->
+                        RadioButton(selected = engine == et, onClick = { engine = et })
+                        Text(et.name)
+                        Spacer(Modifier.width(8.dp))
+                    }
+                }
+
+                Spacer(Modifier.height(8.dp))
+                Text("Default Volume: ${(volume * 100).toInt()}%")
+                Slider(value = volume, onValueChange = { volume = it })
+
+                Spacer(Modifier.height(8.dp))
+                Text("Lyrics Font Size: ${fontSize.toInt()}")
+                Slider(value = fontSize, onValueChange = { fontSize = it }, valueRange = 10f..48f)
+
+                Spacer(Modifier.height(8.dp))
+                OutlinedTextField(
+                    value = color,
+                    onValueChange = { color = it },
+                    label = { Text("Karaoke Color (#RRGGBB)") }
+                )
+
+                Spacer(Modifier.height(16.dp))
+                Row {
+                    Button(onClick = {
+                        onSave(
+                            Settings(theme, engine, volume, fontSize.toInt(), color)
+                        )
+                        onClose()
+                    }) { Text("Save") }
+                    Spacer(Modifier.width(8.dp))
+                    Button(onClick = onClose) { Text("Cancel") }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add JSON-based Settings with theme, engine, volume, font size and color options
- implement Settings dialog and load/save settings between runs
- support volume control in audio engines and new keyboard shortcuts for playback, seeking, volume, file open and playlist toggle

## Testing
- `gradle test` *(fails: Plugin [id: 'org.jetbrains.kotlin.plugin.serialization', version: '1.9.0'] was not found)*

------
https://chatgpt.com/codex/tasks/task_e_689df7c20c848322894a042ab8566f35